### PR TITLE
Add filter to exclude Microsoft accounts

### DIFF
--- a/Metadata/D365FOAdminToolkit/D365FOAdminToolkit/AxClass/ADMDisableUserLastLogin.xml
+++ b/Metadata/D365FOAdminToolkit/D365FOAdminToolkit/AxClass/ADMDisableUserLastLogin.xml
@@ -22,7 +22,7 @@ public class ADMDisableUserLastLogin
 
         select RecId from sr where sr.AotName == '-SYSADMIN-';
 
-        while select forupdate id, name, enable from ui where ui.enable == true
+        while select forupdate id, name, enable from ui where ui.enable == true && ui.isMicrosoftAccount == false
         {
             str userId = ui.id;
 


### PR DESCRIPTION
Hi @ameyer505 

I had a glance at #27, and as the error says, there are triggers on the table that check if it is a service account.

```
CREATE TRIGGER [dbo].[PreventAdminUserDisablementUserInfo]
ON [dbo].[USERINFO]
AFTER UPDATE
AS
BEGIN
    SET NOCOUNT ON;
    SET XACT_ABORT ON;
    IF (UPDATE(enable) and (SELECT count(1) FROM INSERTED I WHERE I.ID='Admin' AND I.ENABLE=0) > 0) --Update
    THROW 51000, 'Admin user cannot be disabled', 1;
END


CREATE TRIGGER [dbo].[PreventPowerPlatformAppUserDisablementUserInfo]
ON [dbo].[USERINFO]
AFTER UPDATE
AS
BEGIN
    SET NOCOUNT ON;
    SET XACT_ABORT ON;
    IF (UPDATE(enable) and (SELECT count(1) FROM INSERTED I WHERE I.ID='PowerPlatformApp' AND I.ENABLE=0) > 0) --Update
    THROW 51000, 'PowerPlatformApp user cannot be disabled!', 1;
END
```

I am concerned that Microsoft might introduce more service accounts in production environments without notice, and our users forget to populate system accounts in the exclude users form.

I propose we make a small modification to the disable user job that excludes users with isMicrosoftAccount == true. If we look at the security role classes in the standard application, there are several places where they check for this field. The accounts we auto-populate in the list are marked with this.

The downside is that the column is not indexed, and there might be a minor performance penalty for instances with many users.

```
    while select forupdate id, name, enable from ui where ui.enable == true && ui.isMicrosoftAccount == false
```

Feel free to close the pull request if you don't see it necessary.