### PR TITLE
Fix save button error in Entra ID Groups

### DIFF
--- a/Metadata/D365FOAdminToolkit/D365FOAdminToolkit/AxClass/ADMEntraIdGroupHelper.xml
+++ b/Metadata/D365FOAdminToolkit/D365FOAdminToolkit/AxClass/ADMEntraIdGroupHelper.xml
@@ -146,12 +146,23 @@ internal final class ADMEntraIdGroupHelper
                 securityRoleAssignmentRule.RuleQuery = query.pack();
                 securityRoleAssignmentRule.ValidFrom = DateTimeUtil::utcNow();
                 securityRoleAssignmentRule.ValidTo = DateTimeUtil::maxValue();
-                securityRoleAssignmentRule.insert();
+                if (securityRoleAssignmentRule.validateWrite())
+                {
+                    securityRoleAssignmentRule.insert();
+                }
+                else
+                {
+                    ttsabort;
+                    return;
+                }
 
                 entraIdGroupSecRoleAssignmentRule.SecurityRole = _secUserRole.SecurityRole;
                 entraIdGroupSecRoleAssignmentRule.UserInfo = _userInfo.RecId;
                 entraIdGroupSecRoleAssignmentRule.SecurityRoleAssignmentRule = securityRoleAssignmentRule.RecId;
-                entraIdGroupSecRoleAssignmentRule.insert();
+                if (entraIdGroupSecRoleAssignmentRule.validateWrite())
+                {
+                    entraIdGroupSecRoleAssignmentRule.insert();
+                }
 
                 ttscommit;
 

--- a/Metadata/D365FOAdminToolkit/D365FOAdminToolkit/AxClass/ADMEntraIdGroupHelper.xml
+++ b/Metadata/D365FOAdminToolkit/D365FOAdminToolkit/AxClass/ADMEntraIdGroupHelper.xml
@@ -131,25 +131,32 @@ internal final class ADMEntraIdGroupHelper
 
             qbds.findRange(fieldNum(ADMEntraIdGroupUserMembership,EntraIdGroup)).value(queryValue(_userInfo.id));
 
-            ttsbegin;
-    
-            securityRoleAssignmentRule.MembershipRuleName = _userInfo.id;
-            securityRoleAssignmentRule.MembershipRuleDescription = _userInfo.name;
-            securityRoleAssignmentRule.SecurityRole = _secUserRole.SecurityRole;
-            securityRoleAssignmentRule.RuleQuery = query.pack();
-            securityRoleAssignmentRule.ValidFrom = DateTimeUtil::utcNow();
-            securityRoleAssignmentRule.ValidTo = DateTimeUtil::maxValue();
-            securityRoleAssignmentRule.insert();
+            // Check for existing record to prevent duplicates
+            select firstonly RecId from entraIdGroupSecRoleAssignmentRule
+                where entraIdGroupSecRoleAssignmentRule.SecurityRole == _secUserRole.SecurityRole
+                   && entraIdGroupSecRoleAssignmentRule.UserInfo == _userInfo.RecId;
 
-            entraIdGroupSecRoleAssignmentRule.SecurityRole = _secUserRole.SecurityRole;
-            entraIdGroupSecRoleAssignmentRule.UserInfo = _userInfo.RecId;
-            entraIdGroupSecRoleAssignmentRule.SecurityRoleAssignmentRule = securityRoleAssignmentRule.RecId;
-            entraIdGroupSecRoleAssignmentRule.insert();
+            if (!entraIdGroupSecRoleAssignmentRule.RecId)
+            {
+                ttsbegin;
+        
+                securityRoleAssignmentRule.MembershipRuleName = _userInfo.id;
+                securityRoleAssignmentRule.MembershipRuleDescription = _userInfo.name;
+                securityRoleAssignmentRule.SecurityRole = _secUserRole.SecurityRole;
+                securityRoleAssignmentRule.RuleQuery = query.pack();
+                securityRoleAssignmentRule.ValidFrom = DateTimeUtil::utcNow();
+                securityRoleAssignmentRule.ValidTo = DateTimeUtil::maxValue();
+                securityRoleAssignmentRule.insert();
 
-            ttscommit;
+                entraIdGroupSecRoleAssignmentRule.SecurityRole = _secUserRole.SecurityRole;
+                entraIdGroupSecRoleAssignmentRule.UserInfo = _userInfo.RecId;
+                entraIdGroupSecRoleAssignmentRule.SecurityRoleAssignmentRule = securityRoleAssignmentRule.RecId;
+                entraIdGroupSecRoleAssignmentRule.insert();
 
-            SysSecurityDynamicRoleAssignment::synchronize(_secUserRole.SecurityRole);
+                ttscommit;
 
+                SysSecurityDynamicRoleAssignment::synchronize(_secUserRole.SecurityRole);
+            }
         }
     }
 

--- a/Metadata/D365FOAdminToolkit/D365FOAdminToolkit/AxClass/ADMEntraIdGroupHelper.xml
+++ b/Metadata/D365FOAdminToolkit/D365FOAdminToolkit/AxClass/ADMEntraIdGroupHelper.xml
@@ -138,7 +138,7 @@ internal final class ADMEntraIdGroupHelper
 
             if (!entraIdGroupSecRoleAssignmentRule.RecId)
             {
-                ttsbegin;
+                UnitofWork unitOfWork = new UnitofWork();
         
                 securityRoleAssignmentRule.MembershipRuleName = _userInfo.id;
                 securityRoleAssignmentRule.MembershipRuleDescription = _userInfo.name;
@@ -146,25 +146,16 @@ internal final class ADMEntraIdGroupHelper
                 securityRoleAssignmentRule.RuleQuery = query.pack();
                 securityRoleAssignmentRule.ValidFrom = DateTimeUtil::utcNow();
                 securityRoleAssignmentRule.ValidTo = DateTimeUtil::maxValue();
-                if (securityRoleAssignmentRule.validateWrite())
-                {
-                    securityRoleAssignmentRule.insert();
-                }
-                else
-                {
-                    ttsabort;
-                    return;
-                }
+
+                unitOfWork.insertonSaveChanges(securityRoleAssignmentRule);
 
                 entraIdGroupSecRoleAssignmentRule.SecurityRole = _secUserRole.SecurityRole;
                 entraIdGroupSecRoleAssignmentRule.UserInfo = _userInfo.RecId;
-                entraIdGroupSecRoleAssignmentRule.SecurityRoleAssignmentRule = securityRoleAssignmentRule.RecId;
-                if (entraIdGroupSecRoleAssignmentRule.validateWrite())
-                {
-                    entraIdGroupSecRoleAssignmentRule.insert();
-                }
+                entraIdGroupSecRoleAssignmentRule.SecurityRoleAssignmentRule(securityRoleAssignmentRule);
 
-                ttscommit;
+                unitOfWork.insertonSaveChanges(entraIdGroupSecRoleAssignmentRule);
+
+                unitOfWork.saveChanges();
 
                 SysSecurityDynamicRoleAssignment::synchronize(_secUserRole.SecurityRole);
             }

--- a/Metadata/D365FOAdminToolkit/D365FOAdminToolkit/AxTable/ADMEntraIdGroupSecurityRoleAssignmentRule.xml
+++ b/Metadata/D365FOAdminToolkit/D365FOAdminToolkit/AxTable/ADMEntraIdGroupSecurityRoleAssignmentRule.xml
@@ -147,9 +147,12 @@ public class ADMEntraIdGroupSecurityRoleAssignmentRule extends common
 			i:type="AxTableRelationForeignKey">
 			<Name>SecurityRoleAssignmentRule</Name>
 			<Cardinality>ZeroOne</Cardinality>
+			<CreateNavigationPropertyMethods>Yes</CreateNavigationPropertyMethods>
 			<RelatedTable>SecurityRoleAssignmentRule</RelatedTable>
 			<RelatedTableCardinality>ZeroOne</RelatedTableCardinality>
+			<RelatedTableRole>SecurityRoleAssignmentRule</RelatedTableRole>
 			<RelationshipType>Association</RelationshipType>
+			<Role>ADMEntraIdGroupSecurityRoleAssignmentRule_SecurityRoleAssignmentRule</Role>
 			<Constraints>
 				<AxTableRelationConstraint xmlns=""
 					i:type="AxTableRelationConstraintField">

--- a/Metadata/D365FOAdminToolkit/Descriptor/D365FOAdminToolkit.xml
+++ b/Metadata/D365FOAdminToolkit/Descriptor/D365FOAdminToolkit.xml
@@ -11,7 +11,9 @@ Website: http://d365foblog.com&#xD;
 Last Updated: Oct 9th 2024</Description>
 	<DisplayName>D365FOAdminToolkit</DisplayName>
 	<Id>896000769</Id>
-	<InternalsVisibleTo xmlns:d2p1="http://schemas.microsoft.com/2003/10/Serialization/Arrays" />
+	<InternalsVisibleTo xmlns:d2p1="http://schemas.microsoft.com/2003/10/Serialization/Arrays">
+		<d2p1:string>D365FOAdminToolkitTests</d2p1:string>
+	</InternalsVisibleTo>
 	<Layer>14</Layer>
 	<Locked>false</Locked>
 	<ModelModule>D365FOAdminToolkit</ModelModule>

--- a/Metadata/D365FOAdminToolkitTests/D365FOAdminToolkitTests/AxClass/ADMEntraIdGroupHelperTest.xml
+++ b/Metadata/D365FOAdminToolkitTests/D365FOAdminToolkitTests/AxClass/ADMEntraIdGroupHelperTest.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AxClass xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+	<Name>ADMEntraIdGroupHelperTest</Name>
+	<SourceCode>
+		<Declaration><![CDATA[
+[SysTestTarget(classStr(ADMEntraIdGroupHelper))]
+public class ADMEntraIdGroupHelperTest extends SysTestCase
+{
+}
+]]></Declaration>
+		<Methods>
+			<Method>
+				<Name>createRoleAssignmentRule_RuleExists_NoError</Name>
+				<Source><![CDATA[
+    /// <summary>
+    /// Ensures that no additional role assignment rule is created if the rule already exists.
+    /// </summary>
+    [SysTestMethod]
+    public void createRoleAssignmentRule_RuleExists_NoError()
+    {
+        // Arrange
+        // create arguments
+        SecurityUserRole securityUserRole;
+        securityUserRole.SecurityRole = 4711;
+        securityUserRole.AssignmentStatus = RoleAssignmentStatus::Enabled;
+
+        UserInfo userInfo;
+        userInfo.RecId = 4711;
+        UserInfo.id = 'User';
+        UserInfo.name = 'User';
+
+        ADMEntraIdGroupDynamicRoleAssignment entraIdGroupDynamicRoleAssignment;
+        entraIdGroupDynamicRoleAssignment.UserInfo = userInfo.RecId;
+        entraIdGroupDynamicRoleAssignment.AutomaticRoleAssignment = NoYes::Yes;
+        entraIdGroupDynamicRoleAssignment.doInsert();
+
+        // create existing rule
+        ADMEntraIdGroupSecurityRoleAssignmentRule entraIdGroupSecRoleAssignmentRule;
+        entraIdGroupSecRoleAssignmentRule.UserInfo = UserInfo.RecId;
+        entraIdGroupSecRoleAssignmentRule.SecurityRole = securityUserRole.SecurityRole;
+        entraIdGroupSecRoleAssignmentRule.doInsert();
+
+        // Act
+        ADMEntraIdGroupHelper::createRoleAssignmentRule(securityUserRole, userInfo);
+
+        // Assert
+        this.assertTrue(true, 'No error should be thrown');
+    }
+
+]]></Source>
+			</Method>
+		</Methods>
+	</SourceCode>
+</AxClass>


### PR DESCRIPTION
Fixes #46

Prevents duplicate records in the `ADMEntraIdGroupSecurityRoleAssignmentRule` table when the "Save" button is pressed in System Administration - Users - Groups.

* Adds a check in the `createRoleAssignmentRule` method of the `ADMEntraIdGroupHelper` class to prevent duplicate records.
* Modifies the `createRoleAssignmentRule` method to include the check before inserting the record.
* Ensures that the error message "Cannot create a record in Entra ID group dynamic role assignment (ADMEntraIdGroupSecurityRoleAssignmentRule). Reference: xxx, System user. The record already exists." is no longer displayed.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ameyer505/D365FOAdminToolkit/issues/46?shareId=44280428-eed9-4830-929d-8a3b31c5dbf5).