### PR TITLE
Improve build action

### DIFF
--- a/.FSC-PS/environments.json
+++ b/.FSC-PS/environments.json
@@ -2,7 +2,7 @@
   {
       "name":"Dummy",
       "settings":{
-          "buildVersion": "10.0.39",
+          "buildVersion": "10.0.40",
           "sourceBranch": "main",
           "lcsEnvironmentId": "12345678-1234-1234-1234-123456789012",
           "azVmname" : "Dummy",

--- a/.FSC-PS/settings.json
+++ b/.FSC-PS/settings.json
@@ -1,7 +1,7 @@
 {
   "type":"FSCM",
   "packageName": "D365FOAdminToolkit",
-  "buildVersion": "10.0.39",
+  "buildVersion": "10.0.40",
   "ciBranches": "main,release",
   "useLocalNuGetStorage":true,
   "deploymentScheduler":false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
       version:
         description: 'Select FSCM Version. Use wildcard * to let settings .json files decide.'
         required: false
-        default: '10.0.39'
+        default: '10.0.40'
 
       includeTestModels:
         type: boolean

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,12 +155,15 @@ jobs:
           version: ${{ matrix.version }}
           settingsJson: ${{ env.Settings }}
           secretsJson: ${{ env.RepoSecrets }}
+
+      - name: Unzip package
+        run: Expand-Archive -Path ${{ env.ARTIFACTS_PATH }}/*.zip -Destination ${{ env.ARTIFACTS_PATH }}/${{ env.PACKAGE_NAME }}
       
       - name: Publish artifacts  
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.PACKAGE_NAME }}
-          path: ${{ env.ARTIFACTS_PATH }}/*.zip
+          path: ${{ env.ARTIFACTS_PATH }}/${{ env.PACKAGE_NAME }}
 
       - name: Add logs to job summary
         run: |


### PR DESCRIPTION
fixes #51 

This pull request includes two changes:
- The default version to build the solution on is increased from 10.0.39 to 10.0.40. Version 10.0.39 is no longer supported since November 22nd, 2024.
- The artifact uploaded to the build action is now a .zip file that can directly uploaded into LCS. Previously, the .zip file contained another .zip file. Only the inner .zip file was recognized as a valid package file by LCS.